### PR TITLE
lodestar.Dockerfile: upgrade LODESTAR_VERSION and DISCV5_VERSION to latest versions

### DIFF
--- a/eth2fuzz/docker/lodestar.Dockerfile
+++ b/eth2fuzz/docker/lodestar.Dockerfile
@@ -30,8 +30,8 @@ RUN make -f eth2fuzz.mk build
 
 FROM ubuntu:18.04
 
-ARG LODESTAR_VERSION="0.11.0"
-ARG DISCV5_VERSION="0.3.2"
+ARG LODESTAR_VERSION="0.13.0"
+ARG DISCV5_VERSION="0.5.0"
 
 # Update ubuntu
 RUN apt-get update && \


### PR DESCRIPTION
Hey!  I noticed that the versions of lodestar and discv5 in the lodestar dockerfile were out of date, so I updated them with the latest versions.